### PR TITLE
chore: improve name for future base exception

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -24,7 +24,7 @@ csharp:
   version: 2.3.0-alpha.1
   additionalDependencies: []
   author: Speakeasy
-  baseErrorName: NovuError
+  baseErrorName: BaseException
   clientServerStatusCodesAsErrors: true
   defaultErrorName: APIException
   disableNamespacePascalCasingApr2024: true


### PR DESCRIPTION
In an upcoming release, all SDK exceptions will inherit from a _base_ exception to ease error handling. Given that the _default_ exception is currently named `APIException`, this PR aims at improving naming consistency by editing the `baseErrorName` configuration parameter. Note this configuration change is a no-op for now and will only have effect once the new Error handling feature is released.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed the base exception type in the C# SDK from “NovuError” to “BaseException” to align error handling.
  * This may require updating references in applications that catch or extend the previous exception type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->